### PR TITLE
Fix MUC room join presence detection (prevents pending messages)

### DIFF
--- a/src/networking/xmpp/presenceInRoom.xmpp.ts
+++ b/src/networking/xmpp/presenceInRoom.xmpp.ts
@@ -1,39 +1,58 @@
 import { Client, xml } from '@xmpp/client';
-import { createTimeoutPromise } from './createTimeoutPromise.xmpp';
 import { Element } from '@xmpp/xml';
 export const presenceInRoom = async (
   client: Client,
   roomJID: string,
-  delay = 2000
-): Promise<Element> => {
-  let stanzaHandler: (stanza: Element) => void;
+  delay = 2000,
+  timeoutMs = 6000
+): Promise<Element | null> => {
+  let stanzaHandler: ((stanza: Element) => void) | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  const unsubscribe = () => client.off('stanza', stanzaHandler);
+  const unsubscribe = () => {
+    try {
+      if (stanzaHandler) client.off('stanza', stanzaHandler);
+    } catch (e) {}
+    stanzaHandler = null;
+  };
 
   return new Promise(async (resolve, reject) => {
     let settled = false;
 
-    const finish = (cb: (value?: any) => void, value?: any) => {
+    const finish = (value: Element | null) => {
       if (settled) return;
       settled = true;
-
+      if (timeoutId) clearTimeout(timeoutId);
+      // Small delay keeps join/roster churn calmer for some servers.
       setTimeout(() => {
         unsubscribe();
-        cb(value);
+        resolve(value);
       }, delay);
     };
 
     stanzaHandler = (stanza) => {
-      if (
-        stanza.is('presence') &&
-        stanza.attrs.id === 'presenceInRoom' &&
-        stanza.attrs.from?.startsWith(roomJID)
-      ) {
-        finish(resolve, stanza);
-      }
+      if (!stanza.is('presence')) return;
+      if (!stanza.attrs?.from?.startsWith(`${roomJID}/`)) return;
+
+      // Different servers may not preserve/echo our 'id' attribute.
+      // We treat any MUC-related presence from the room as a join confirmation.
+      const mucUserX = stanza.getChild(
+        'x',
+        'http://jabber.org/protocol/muc#user'
+      );
+      const mucX = stanza.getChild('x', 'http://jabber.org/protocol/muc');
+      if (!mucUserX && !mucX) return;
+
+      finish(stanza);
     };
 
     client.on('stanza', stanzaHandler);
+
+    timeoutId = setTimeout(() => {
+      // Don't reject: callers use this only as a "best effort" join.
+      // If we reject here, it can block presencesReady and keep messages pending forever.
+      finish(null);
+    }, timeoutMs);
 
     const presence = xml(
       'presence',
@@ -48,10 +67,9 @@ export const presenceInRoom = async (
     try {
       await client.send(presence);
     } catch (err) {
+      if (timeoutId) clearTimeout(timeoutId);
       unsubscribe();
-      return [];
+      reject(err);
     }
-
-    await createTimeoutPromise(2000, unsubscribe).catch(reject);
   });
 };


### PR DESCRIPTION
## Summary
- Fixes `presenceInRoom()` to **not rely on the server echoing `id=presenceInRoom`** in presence stanzas.
- Detects successful MUC join using **`from=roomJID/resource` + MUC `<x xmlns=...>`**, which is consistent with ejabberd and other servers.
- Avoids rejecting on join timeout (best-effort join), preventing message resend loops that can keep messages stuck as *pending*.

## Why this is needed
In real deployments we observed that the web client can connect (XMPP echo healthcheck OK) but UI **never shows the double/green tick** for sent messages. In this codebase the tick is driven by whether the message remains in the local heap (pending). When join confirmation fails, the client can hit `Only occupants are allowed to send messages to the conference.` errors, and the recovery handler repeatedly tries to send presence + (re)join, but join confirmation never arrives because the helper was waiting for an echoed `id` that ejabberd does not reliably preserve.

This change makes room join detection robust across servers and stops the "presence retry → resend queue → pending forever" failure mode.

## Test plan
- Send a message to a MUC room while connected to ejabberd.
- Verify that, after a transient "Only occupants…" error, the client successfully rejoins and pending messages flush (double-tick appears).

## Notes
Local CI checks in this repo currently fail unrelated to this PR:
- `npm run lint` fails because ESLint v9 expects `eslint.config.*` by default.
- `npm run build:lib` fails due to missing `react-use-measure` during compilation.
These failures existed before this change; this PR only updates the presence join helper.