### PR TITLE
chore(config): default to chat.ethora.com hosts after prod migration

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,7 +1,7 @@
-export const VITE_APP_API_URL = 'https://api.ethoradev.com/v1';
+export const VITE_APP_API_URL = 'https://api.chat.ethora.com/v1';
 export const VITE_APP_DISABLE_STRICT = 'true';
-export const VITE_APP_DOMAIN_NAME = 'ethoradev.com';
-export const VITE_APP_XMPP_BASEDOMAIN_OLD = 'xmpp.ethoradev.com';
-export const VITE_APP_XMPP_BASEDOMAIN = 'xmpp.ethoradev.com';
+export const VITE_APP_DOMAIN_NAME = 'chat.ethora.com';
+export const VITE_APP_XMPP_BASEDOMAIN_OLD = 'xmpp.chat.ethora.com';
+export const VITE_APP_XMPP_BASEDOMAIN = 'xmpp.chat.ethora.com';
 
 export const SERVICE = `wss://${VITE_APP_XMPP_BASEDOMAIN_OLD}:5443/ws`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,11 @@ import { ethoraLogger } from './helpers/ethoraLogger';
 
 const APP_CHAT_BASE_CONFIG: IConfig = {
   appId: '646cc8dc96d4a4dc8f7b2f2d',
-  baseUrl: 'https://api.ethoradev.com/v1',
+  baseUrl: 'https://api.chat.ethora.com/v1',
   xmppSettings: {
-    devServer: 'wss://xmpp.ethoradev.com:5443/ws',
-    host: 'xmpp.ethoradev.com',
-    conference: 'conference.xmpp.ethoradev.com',
+    devServer: 'wss://xmpp.chat.ethora.com:5443/ws',
+    host: 'xmpp.chat.ethora.com',
+    conference: 'conference.xmpp.chat.ethora.com',
     xmppPingOnSendEnabled: true,
   },
   userLogin: {
@@ -97,7 +97,7 @@ const Apps = () => {
               CustomScrollableArea={CustomScrollableArea}
               CustomDaySeparator={CustomDaySeparator}
               config={{
-                baseUrl: 'https://api.ethoradev.com/v1',
+                baseUrl: 'https://api.chat.ethora.com/v1',
                 inAppNotifications: {
                   enabled: true,
                   showInContext: true, // Show in chat component context as well
@@ -181,7 +181,7 @@ const ChatComponent = React.memo(() => {
         // CustomInputComponent={CustomChatInput}
         // CustomScrollableArea={CustomScrollableArea}
         // CustomDaySeparator={CustomDaySeparator}
-        // roomJID="646cc8dc96d4a4dc8f7b2f2d_6824685682d635dba7522423@conference.xmpp.ethoradev.com"
+        // roomJID="646cc8dc96d4a4dc8f7b2f2d_6824685682d635dba7522423@conference.xmpp.chat.ethora.com"
         // roomJID="6998429ba125477a74a7dcef_69b96235545b8217d39dc1ac@conference.xmpp-dev.preshent.com"
         config={{
           // ...(demoJwtToken

--- a/src/AppWithNav.tsx
+++ b/src/AppWithNav.tsx
@@ -6,11 +6,11 @@ const Apps = () => <div>Apps</div>;
 const Chat = () => (
   <div>
     <ReduxWrapper
-      // roomJID="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78.0x912_b587_d8c931256_d35898829690_d1_d956bf_f8c9@conference.xmpp.ethoradev.com"
-      // random 5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com
-      // deppx 57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.ethoradev.com
-      // test 8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.ethoradev.com
-      // three d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.ethoradev.com
+      // roomJID="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78.0x912_b587_d8c931256_d35898829690_d1_d956bf_f8c9@conference.xmpp.chat.ethora.com"
+      // random 5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com
+      // deppx 57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.chat.ethora.com
+      // test 8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.chat.ethora.com
+      // three d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.chat.ethora.com
       config={{
         // disableHeader: true,
         colors: { primary: '#5E3FDE', secondary: '#E1E4FE' },
@@ -29,17 +29,17 @@ const Chat = () => (
         refreshTokens: { enabled: true },
         // defaultRooms: [
         //   {
-        //     jid: '5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com',
+        //     jid: '5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com',
         //     pinned: true,
         //     _id: '6672807fef55364c13703235',
         //   },
         //   {
-        //     jid: '6c00199ef7fb86d09b10f70c353411c70fe7f75847cacdb322c813416bcc33ab@conference.xmpp.ethoradev.com',
+        //     jid: '6c00199ef7fb86d09b10f70c353411c70fe7f75847cacdb322c813416bcc33ab@conference.xmpp.chat.ethora.com',
         //     pinned: false,
         //     _id: '6672807fef55364c13703236',
         //   },
         //   {
-        //     jid: 'd673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.ethoradev.com',
+        //     jid: 'd673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.chat.ethora.com',
         //     pinned: false,
         //     _id: '6672807fef55364c13703237',
         //   },

--- a/src/api.config.js
+++ b/src/api.config.js
@@ -28,11 +28,11 @@ export const defaultUser = {
   username: '',
 };
 export const defRoom = {
-  // jid: "8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.ethoradev.com", // default
-  // jid: "61ca3489a54efe5dc1517bc24d5c8982cc369428b333b1f7a14f46d70ac70bfd@conference.xmpp.ethoradev.com", // deepx
-  // jid: "5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com", // general
-  // jid: "70ad0f490034cf85f12f09fe88a83165302c59592cbedf9f8dbbea755bc5e180@conference.xmpp.ethoradev.com", // empty
-  jid: '74e12f74fa9c1f09f2a04b704107f4382a9682072b77632d8bf2e1b8618d2c3e@conference.xmpp.ethoradev.com',
+  // jid: "8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.chat.ethora.com", // default
+  // jid: "61ca3489a54efe5dc1517bc24d5c8982cc369428b333b1f7a14f46d70ac70bfd@conference.xmpp.chat.ethora.com", // deepx
+  // jid: "5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com", // general
+  // jid: "70ad0f490034cf85f12f09fe88a83165302c59592cbedf9f8dbbea755bc5e180@conference.xmpp.chat.ethora.com", // empty
+  jid: '74e12f74fa9c1f09f2a04b704107f4382a9682072b77632d8bf2e1b8618d2c3e@conference.xmpp.chat.ethora.com',
   name: '1234',
   users_cnt: '1',
   unreadMessages: 0,

--- a/src/api.config.ts
+++ b/src/api.config.ts
@@ -30,5 +30,5 @@ export const defaultUser = {
 };
 
 export const defRoom = {
-  jid: '5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com',
+  jid: '5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com',
 };

--- a/src/assets/test.xml
+++ b/src/assets/test.xml
@@ -1,73 +1,73 @@
 //history
-<message xmlns="jabber:client" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727189657257" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com">
+<message xmlns="jabber:client" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727189657257" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com">
 	<result id="1727188885290611" xmlns="urn:xmpp:mam:2">
 		<forwarded xmlns="urn:xmpp:forward:0">
-			<message xml:lang="en" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727188885167" xmlns="jabber:client">
+			<message xml:lang="en" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727188885167" xmlns="jabber:client">
 				<x xmlns="http://jabber.org/protocol/muc#user">
-					<item jid="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727188880221" />
+					<item jid="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727188880221" />
 				</x>
-				<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727188885290611" xmlns="urn:xmpp:mam:tmp" />
-				<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727188885290611" xmlns="urn:xmpp:sid:0" />
-				<data xmlns="conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" senderFirstName="e" senderLastName="m" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727188880221" senderWalletAddress="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" isSystemMessage="false" photoURL="" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
+				<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727188885290611" xmlns="urn:xmpp:mam:tmp" />
+				<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727188885290611" xmlns="urn:xmpp:sid:0" />
+				<data xmlns="conference.xmpp.example.com" senderFirstName="e" senderLastName="m" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727188880221" senderWalletAddress="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" isSystemMessage="false" photoURL="" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
 				<body>
 					123as
 				</body>
 			</message>
-			<delay from="conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" stamp="2024-09-24T14:41:25.290611Z" xmlns="urn:xmpp:delay" />
+			<delay from="conference.xmpp.example.com" stamp="2024-09-24T14:41:25.290611Z" xmlns="urn:xmpp:delay" />
 		</forwarded>
 	</result>
 </message>
 //
-<message xmlns="jabber:client" to="0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@xmpp.ethoradev.com/83567038000300810213249042" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com">
+<message xmlns="jabber:client" to="0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@xmpp.chat.ethora.com/83567038000300810213249042" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com">
 	<result id="1739806397073165" xmlns="urn:xmpp:mam:2">
 		<forwarded xmlns="urn:xmpp:forward:0">
-			<message xml:lang="en" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com/0x80f_f29_dcd7_e6_dd7c_c90_b47f_ed45669c_f021a0_e_c6" type="groupchat" xmlns="jabber:client">
-				<archived by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" id="1739806397073165" xmlns="urn:xmpp:mam:tmp" />
-				<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" id="1739806397073165" xmlns="urn:xmpp:sid:0" />
+			<message xml:lang="en" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com/0x80f_f29_dcd7_e6_dd7c_c90_b47f_ed45669c_f021a0_e_c6" type="groupchat" xmlns="jabber:client">
+				<archived by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" id="1739806397073165" xmlns="urn:xmpp:mam:tmp" />
+				<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" id="1739806397073165" xmlns="urn:xmpp:sid:0" />
 				<data xmlns="jabber:client" fullName="AI Assistant" senderFirstName="AI Assistant" senderLastName="AI" showInChannel="true" />
 				<body>
 					There is no prominent figure known as Elon Trump. Elon Musk is the CEO of Tesla and SpaceX, while Donald Trump is a former President of the United States.
 				</body>
 			</message>
-			<delay from="conference.xmpp.ethoradev.com" stamp="2025-02-17T15:33:17.073165Z" xmlns="urn:xmpp:delay" />
+			<delay from="conference.xmpp.chat.ethora.com" stamp="2025-02-17T15:33:17.073165Z" xmlns="urn:xmpp:delay" />
 		</forwarded>
 	</result>
 </message>
 //realtime
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727199505078" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727199609430">
-	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727199609620712" xmlns="urn:xmpp:mam:tmp" />
-	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727199609620712" xmlns="urn:xmpp:sid:0" />
-	<data xmlns="wss://case-any-place-iframe-xmpp-dev.atomwcapps.com:5443/ws" senderFirstName="emp1 emp1" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/26663382910864279623267" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" isSystemMessage="false" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727199505078" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727199609430">
+	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727199609620712" xmlns="urn:xmpp:mam:tmp" />
+	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727199609620712" xmlns="urn:xmpp:sid:0" />
+	<data xmlns="wss://xmpp.example.com:5443/ws" senderFirstName="emp1 emp1" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/26663382910864279623267" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" isSystemMessage="false" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
 	<body>
 		1251
 	</body>
 </message>
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727189642496" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727189963389">
-	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727189963581654" xmlns="urn:xmpp:mam:tmp" />
-	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727189963581654" xmlns="urn:xmpp:sid:0" />
-	<data xmlns="conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" senderFirstName="e" senderLastName="m" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727189657257" senderWalletAddress="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" isSystemMessage="false" photoURL="" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727189642496" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727189963389">
+	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727189963581654" xmlns="urn:xmpp:mam:tmp" />
+	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727189963581654" xmlns="urn:xmpp:sid:0" />
+	<data xmlns="conference.xmpp.example.com" senderFirstName="e" senderLastName="m" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727189657257" senderWalletAddress="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" isSystemMessage="false" photoURL="" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
 	<body>
 		111123
 	</body>
 </message>
 //composing
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727199505078" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="typing-1727199608465">
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727199505078" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="typing-1727199608465">
 	<composing xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="emp1 emp1" />
-	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727199608653240" xmlns="urn:xmpp:sid:0" />
+	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727199608653240" xmlns="urn:xmpp:sid:0" />
 </message>
-<message xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/1029570399890456970131474" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com/0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78" type="groupchat" id="typing-1727398801870">
+<message xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/1029570399890456970131474" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com/0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78" type="groupchat" id="typing-1727398801870">
 	<composing xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="Raze Yuki" />
-	<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" id="1727398802037869" xmlns="urn:xmpp:sid:0" />
+	<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" id="1727398802037869" xmlns="urn:xmpp:sid:0" />
 </message>
 //paused
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727199448461" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="stop-typing-1727199611818">
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727199448461" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="stop-typing-1727199611818">
 	<paused xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="emp1 emp1" />
-	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727199612009461" xmlns="urn:xmpp:sid:0" />
+	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727199612009461" xmlns="urn:xmpp:sid:0" />
 </message>
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727213816335" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" type="error" id="typing-1727213820721">
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727213816335" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6" type="error" id="typing-1727213820721">
 	<paused xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="e m" />
 	<error type="cancel">
@@ -77,37 +77,37 @@
 		</text>
 	</error>
 </message>
-<message xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/1029570399890456970131474" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com/0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78" type="groupchat" id="typing-1727398803922">
+<message xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/1029570399890456970131474" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com/0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78" type="groupchat" id="typing-1727398803922">
 	<paused xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="Raze Yuki" />
-	<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" id="1727398804087352" xmlns="urn:xmpp:sid:0" />
+	<stanza-id by="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" id="1727398804087352" xmlns="urn:xmpp:sid:0" />
 </message>
 //subject
-<message xmlns="jabber:client" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727200763551" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" type="groupchat">
+<message xmlns="jabber:client" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727200763551" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" type="groupchat">
 	<subject />
 </message>
-<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/1727200854781" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727200901894">
-	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727200902055525" xmlns="urn:xmpp:mam:tmp" />
-	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" id="1727200902055525" xmlns="urn:xmpp:sid:0" />
-	<data xmlns="wss://case-any-place-iframe-xmpp-dev.atomwcapps.com:5443/ws" senderFirstName="emp1 emp1" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@case-any-place-iframe-xmpp-dev.atomwcapps.com/472486283397765324543202" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.case-any-place-iframe-xmpp-dev.atomwcapps.com" isSystemMessage="false" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
+<message xmlns="jabber:client" xml:lang="en" to="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/1727200854781" from="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com/3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156" type="groupchat" id="send-message:1727200901894">
+	<archived by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727200902055525" xmlns="urn:xmpp:mam:tmp" />
+	<stanza-id by="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" id="1727200902055525" xmlns="urn:xmpp:sid:0" />
+	<data xmlns="wss://xmpp.example.com:5443/ws" senderFirstName="emp1 emp1" senderJID="3ca9c8541c020dee4ff34077dd1006323464eca35353cd74cde2b71bfa6b2156@xmpp.example.com/472486283397765324543202" roomJid="da866751f3915731b5e408a2a2531355f7eba2f2c5bc00c5126889a5995e9bd6@conference.xmpp.example.com" isSystemMessage="false" tokenAmount="0" quickReplies="" notDisplayedValue="" showInChannel="true" />
 	<body>
 		9087
 	</body>
 </message>
-<message type="groupchat" id="typing-1727449049844" to="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" xmlns="jabber:client">
+<message type="groupchat" id="typing-1727449049844" to="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" xmlns="jabber:client">
 	<composing xmlns="http://jabber.org/protocol/chatstates" />
 	<data fullName="test test" />
 </message>
-<message xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/1189077568371589559545426" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com">
+<message xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/1189077568371589559545426" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com">
 	<result id="1727969410723554" queryid="userArchive" xmlns="urn:xmpp:mam:2">
 		<forwarded xmlns="urn:xmpp:forward:0">
-			<message to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" from="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.ethoradev.com" id="17147864347420389854" xmlns="jabber:client">
-				<archived by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" id="1727969410723554" xmlns="urn:xmpp:mam:tmp" />
-				<stanza-id by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" id="1727969410723554" xmlns="urn:xmpp:sid:0" />
+			<message to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" from="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.chat.ethora.com" id="17147864347420389854" xmlns="jabber:client">
+				<archived by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" id="1727969410723554" xmlns="urn:xmpp:mam:tmp" />
+				<stanza-id by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" id="1727969410723554" xmlns="urn:xmpp:sid:0" />
 				<event xmlns="http://jabber.org/protocol/pubsub#event">
 					<items node="urn:xmpp:mucsub:nodes:presence">
 						<item id="17147864347420389854">
-							<presence xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" from="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.ethoradev.com/0x9_c475da5_fa_ff_d_b175_fc286_b2b0581_ed48e674_cbf" type="unavailable">
+							<presence xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" from="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.chat.ethora.com/0x9_c475da5_fa_ff_d_b175_fc286_b2b0581_ed48e674_cbf" type="unavailable">
 								<x xmlns="http://jabber.org/protocol/muc#user">
 									<item role="none" affiliation="none" />
 								</x>
@@ -116,20 +116,20 @@
 					</items>
 				</event>
 			</message>
-			<delay from="xmpp.ethoradev.com" stamp="2024-10-03T15:30:10.723554Z" xmlns="urn:xmpp:delay" />
+			<delay from="xmpp.chat.ethora.com" stamp="2024-10-03T15:30:10.723554Z" xmlns="urn:xmpp:delay" />
 		</forwarded>
 	</result>
 </message>
-<message xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/287950209239444818056227" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com">
+<message xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/287950209239444818056227" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com">
 	<result id="1728534590392664" queryid="userArchive" xmlns="urn:xmpp:mam:2">
 		<forwarded xmlns="urn:xmpp:forward:0">
-			<message to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" from="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.ethoradev.com" id="11358382913258728319" xmlns="jabber:client">
-				<archived by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" id="1728534590392664" xmlns="urn:xmpp:mam:tmp" />
-				<stanza-id by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" id="1728534590392664" xmlns="urn:xmpp:sid:0" />
+			<message to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" from="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.chat.ethora.com" id="11358382913258728319" xmlns="jabber:client">
+				<archived by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" id="1728534590392664" xmlns="urn:xmpp:mam:tmp" />
+				<stanza-id by="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" id="1728534590392664" xmlns="urn:xmpp:sid:0" />
 				<event xmlns="http://jabber.org/protocol/pubsub#event">
 					<items node="urn:xmpp:mucsub:nodes:presence">
 						<item id="11358382913258728319">
-							<presence xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" from="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.ethoradev.com/0x239619_f_dda54_f471_febfb_e048_eb9238ea_f_e5_d360" type="unavailable">
+							<presence xmlns="jabber:client" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" from="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.chat.ethora.com/0x239619_f_dda54_f471_febfb_e048_eb9238ea_f_e5_d360" type="unavailable">
 								<x xmlns="http://jabber.org/protocol/muc#user">
 									<item role="none" affiliation="none" />
 								</x>
@@ -138,34 +138,34 @@
 					</items>
 				</event>
 			</message>
-			<delay from="xmpp.ethoradev.com" stamp="2024-10-10T04:29:50.392664Z" xmlns="urn:xmpp:delay" />
+			<delay from="xmpp.chat.ethora.com" stamp="2024-10-10T04:29:50.392664Z" xmlns="urn:xmpp:delay" />
 		</forwarded>
 	</result>
 </message>
 //roomInfo
-<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/14275056360500819986101106" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" type="result" id="getUserRooms">
+<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/14275056360500819986101106" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" type="result" id="getUserRooms">
 	<query xmlns="ns:getrooms">
-		<room room_background="none" room_thumbnail="none" name="Random talks" users_cnt="115" jid="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" name="ChatTwo" users_cnt="111" jid="6c00199ef7fb86d09b10f70c353411c70fe7f75847cacdb322c813416bcc33ab@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" name="Chat Three" users_cnt="110" jid="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.ethoradev.com" />
-		<room name="TestChat" users_cnt="2" jid="8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.ethoradev.com" />
-		<room name="Deepxchat" users_cnt="4" jid="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.ethoradev.com" />
-		<room name="testroomnew" users_cnt="1" jid="61ca3489a54efe5dc1517bc24d5c8982cc369428b333b1f7a14f46d70ac70bfd@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" name="no messages test" users_cnt="2" jid="70ad0f490034cf85f12f09fe88a83165302c59592cbedf9f8dbbea755bc5e180@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" name="1234Test" users_cnt="2" jid="9d0505ca318a5c0dee6cc9ae50d9dc72f1cf61aa8fb3a15e66045dc31ebd8c5c@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" name="5test" users_cnt="2" jid="b76a90d9c753cbb4697a1d22b32611110008bb87671ed332269a339b07ffee50@conference.xmpp.ethoradev.com" />
-		<room room_background="none" room_thumbnail="none" users_cnt="1" jid="b76a90d9c753cbb4697a1d22b32611110008bb87671ed332269a339b07ffee50c@conference.xmpp.ethoradev.com" />
+		<room room_background="none" room_thumbnail="none" name="Random talks" users_cnt="115" jid="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" name="ChatTwo" users_cnt="111" jid="6c00199ef7fb86d09b10f70c353411c70fe7f75847cacdb322c813416bcc33ab@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" name="Chat Three" users_cnt="110" jid="d673a602b47d524ba6a95102cc71fc3f308b31d64454498078a056cf54e5a2b4@conference.xmpp.chat.ethora.com" />
+		<room name="TestChat" users_cnt="2" jid="8ef200ac9dffd7b7b6ba0ee5a9df4d8b33c38877eb771ca1f5a3e6966b9d39f0@conference.xmpp.chat.ethora.com" />
+		<room name="Deepxchat" users_cnt="4" jid="57834759e627abd4ee3d10b4df859d1665753c208206419e5ffaa0e384137ba3@conference.xmpp.chat.ethora.com" />
+		<room name="testroomnew" users_cnt="1" jid="61ca3489a54efe5dc1517bc24d5c8982cc369428b333b1f7a14f46d70ac70bfd@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" name="no messages test" users_cnt="2" jid="70ad0f490034cf85f12f09fe88a83165302c59592cbedf9f8dbbea755bc5e180@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" name="1234Test" users_cnt="2" jid="9d0505ca318a5c0dee6cc9ae50d9dc72f1cf61aa8fb3a15e66045dc31ebd8c5c@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" name="5test" users_cnt="2" jid="b76a90d9c753cbb4697a1d22b32611110008bb87671ed332269a339b07ffee50@conference.xmpp.chat.ethora.com" />
+		<room room_background="none" room_thumbnail="none" users_cnt="1" jid="b76a90d9c753cbb4697a1d22b32611110008bb87671ed332269a339b07ffee50c@conference.xmpp.chat.ethora.com" />
 	</query>
 </iq>
 //RoomMembers
-<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/4086937129455425396216227" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" type="result" id="roomMemberInfo">
+<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/4086937129455425396216227" from="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" type="result" id="roomMemberInfo">
 	<query xmlns="ns:room:last">
-		<activity profile="none" name="test test" role="owner" ban_status="clear" last_active="1731677817" jid="0xd_e5c0_b_d_a33953327_f5_cb_d79_e7_b58_e_b7_e_b425_b324@xmpp.ethoradev.com" />
-		<activity profile="none" name="Raze Yuki" role="none" ban_status="clear" last_active="1731074001" jid="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com" />
+		<activity profile="none" name="test test" role="owner" ban_status="clear" last_active="1731677817" jid="0xd_e5c0_b_d_a33953327_f5_cb_d79_e7_b58_e_b7_e_b425_b324@xmpp.chat.ethora.com" />
+		<activity profile="none" name="Raze Yuki" role="none" ban_status="clear" last_active="1731074001" jid="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com" />
 	</query>
 </iq>
 //oneRoomInfo
-<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.ethoradev.com/12846947728090643117216163" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.ethoradev.com" type="result" id="roomInfo">
+<iq xmlns="jabber:client" xml:lang="en" to="0x6816810a7_fe04_f_c9b800f9_d11564_c0e4a_e_c25_d78@xmpp.chat.ethora.com/12846947728090643117216163" from="5f9a4603b2b5bbfa6b228b642127c56d03b778ad594c52b755e605c977303979@conference.xmpp.chat.ethora.com" type="result" id="roomInfo">
 	<query xmlns="http://jabber.org/protocol/disco#info">
 		<identity name="Random talks" type="text" category="conference" />
 		<feature var="vcard-temp" />
@@ -260,7 +260,7 @@
 //
 get-history
 0x6_c394_b10_f5_da4141b99_d_b2_ad424_c5688c3f202_b3.0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9
-<iq xmlns="jabber:client" xml:lang="en" to="0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@xmpp.ethoradev.com/85328763516285310342948706" from="0x6_c394_b10_f5_da4141b99_d_b2_ad424_c5688c3f202_b3.0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@conference.xmpp.ethoradev.com" type="result" id="get-history:1739214575011">
+<iq xmlns="jabber:client" xml:lang="en" to="0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@xmpp.chat.ethora.com/85328763516285310342948706" from="0x6_c394_b10_f5_da4141b99_d_b2_ad424_c5688c3f202_b3.0x_b46998202834_b455396508277f36f66d05_a_a_e8_f9@conference.xmpp.chat.ethora.com" type="result" id="get-history:1739214575011">
 	<fin complete="true" xmlns="urn:xmpp:mam:2">
 		<set xmlns="http://jabber.org/protocol/rsm">
 			<count>
@@ -270,9 +270,9 @@ get-history
 	</fin>
 </iq>
 //when user deleted from chat:
-<presence xmlns="jabber:client" to="67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4@dev.xmpp.ethoradev.com/218076858337444426029954" from="67d3cc45b5018b9872c16a0b_67eabb5a156fbdfe28039a50@conference.dev.xmpp.ethoradev.com/67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4" type="unavailable">
+<presence xmlns="jabber:client" to="67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4@xmpp.chat.ethora.com/218076858337444426029954" from="67d3cc45b5018b9872c16a0b_67eabb5a156fbdfe28039a50@conference.xmpp.chat.ethora.com/67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4" type="unavailable">
 	<x xmlns="http://jabber.org/protocol/muc#user">
-		<item jid="67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4@dev.xmpp.ethoradev.com/218076858337444426029954" role="none" affiliation="none" />
+		<item jid="67d3cc45b5018b9872c16a0b_67d3cde6b5018b9872c16ac4@xmpp.chat.ethora.com/218076858337444426029954" role="none" affiliation="none" />
 		<status code="110" />
 		<status code="321" />
 	</x>

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,9 +5,9 @@ const normalizeHost = (value?: string): string =>
   (value || '').replace(/^https?:\/\//, '').replace(/\/.*$/, '').trim();
 
 export const VITE_APP_API_URL =
-  env['VITE_API'] || env['VITE_WIDGET_API_URL'] || 'https://api.ethoradev.com/v1';
+  env['VITE_API'] || env['VITE_WIDGET_API_URL'] || 'https://api.chat.ethora.com/v1';
 export const VITE_APP_DISABLE_STRICT = 'true';
-export const VITE_APP_DOMAIN_NAME = env['VITE_DOMAIN_NAME'] || 'ethoradev.com';
+export const VITE_APP_DOMAIN_NAME = env['VITE_DOMAIN_NAME'] || 'chat.ethora.com';
 export const VITE_APP_WEB_DOMAIN = normalizeHost(env['VITE_WEB_DOMAIN']);
 export const VITE_APP_WEB_URL = VITE_APP_WEB_DOMAIN
   ? `https://${VITE_APP_WEB_DOMAIN}`
@@ -15,7 +15,7 @@ export const VITE_APP_WEB_URL = VITE_APP_WEB_DOMAIN
 export const VITE_APP_XMPP_BASEDOMAIN_OLD = normalizeHost(
   env['VITE_XMPP_HOST'] ||
     env['VITE_WIDGET_XMPP_DOMAIN'] ||
-    'xmpp.ethoradev.com'
+    'xmpp.chat.ethora.com'
 );
 export const VITE_APP_XMPP_BASEDOMAIN = VITE_APP_XMPP_BASEDOMAIN_OLD;
 export const VITE_APP_XMPP_CONFERENCE =

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -137,7 +137,7 @@ const usePushNotifications = (
       if (!jid) return '';
       if (jid.includes('@')) return jid;
       const conference =
-        config?.xmppSettings?.conference || 'conference.xmpp.ethoradev.com';
+        config?.xmppSettings?.conference || 'conference.xmpp.chat.ethora.com';
       return `${jid}@${conference}`;
     },
     [config?.xmppSettings?.conference]

--- a/src/networking/xmpp/subscribeToRoomMessages.xmpp.ts
+++ b/src/networking/xmpp/subscribeToRoomMessages.xmpp.ts
@@ -32,7 +32,7 @@ export async function subscribeToRoomMessages(
       }, 500);
     };
 
-    // <iq xmlns='jabber:client' xml:lang='en' to='646cc8dc96d4a4dc8f7b2f2d_69a6358f66cb3e74bcbcd6b2@xmpp.ethoradev.com/515555070583875399454338' from='646cc8dc96d4a4dc8f7b2f2d_69a6376b66cb3e74bcbcda9f@conference.xmpp.ethoradev.com' type='result' id='newSubscription:1772618245224'><subscribe nick='646cc8dc96d4a4dc8f7b2f2d_69a6358f66cb3e74bcbcd6b2' xmlns='urn:xmpp:mucsub:0'><event node='urn:xmpp:mucsub:nodes:messages'/></subscribe></iq>
+    // <iq xmlns='jabber:client' xml:lang='en' to='646cc8dc96d4a4dc8f7b2f2d_69a6358f66cb3e74bcbcd6b2@xmpp.chat.ethora.com/515555070583875399454338' from='646cc8dc96d4a4dc8f7b2f2d_69a6376b66cb3e74bcbcda9f@conference.xmpp.chat.ethora.com' type='result' id='newSubscription:1772618245224'><subscribe nick='646cc8dc96d4a4dc8f7b2f2d_69a6358f66cb3e74bcbcd6b2' xmlns='urn:xmpp:mucsub:0'><event node='urn:xmpp:mucsub:nodes:messages'/></subscribe></iq>
 
     stanzaHandler = (stanza: Element) => {
       if (stanza.is('iq') && stanza.attrs.id === id) {


### PR DESCRIPTION
## Summary

Production has migrated from `*.ethoradev.com` to `*.chat.ethora.com`. This PR is a small, focused update to the package's **built-in default hosts** so that any consumer of `@ethora/chat-component` who does not override `baseUrl` / `xmppSettings` automatically targets the new prod cluster instead of the dead one.

This is a tighter subset of the broader chat.ethora.com migration work currently sitting on \`tf-dev\`. It is intentionally extracted into its own PR so it can be reviewed and merged quickly without coupling to the rest of the \`tf-dev\` work.

### Changes

Files touched (all in \`src/*\` plus root \`config.ts\`):

- \`config.ts\`, \`src/config.ts\` — API base URL, XMPP host, conference, domain defaults switched to chat.ethora.com.
- \`src/App.tsx\` — \`APP_CHAT_BASE_CONFIG\` defaults updated; the second \`ReduxWrapper\` config block also moved to \`api.chat.ethora.com\`.
- \`src/AppWithNav.tsx\` — commented JID examples (kept verbatim, only host rewritten so they remain accurate references).
- \`src/api.config.{ts,js}\` — \`defRoom\` example JIDs updated to the new conference host.
- \`src/hooks/usePushNotifications.ts\` — conference fallback updated.
- \`src/networking/xmpp/subscribeToRoomMessages.xmpp.ts\` — commented IQ example updated.
- \`src/assets/test.xml\` — replaced the leaked private host \`case-any-place-iframe-xmpp-dev.atomwcapps.com\` with \`xmpp.example.com\`, and rewrote remaining \`xmpp.ethoradev.com\` / \`dev.xmpp.ethoradev.com\` entries to \`xmpp.chat.ethora.com\`.

### Out of scope (intentional)

- \`lib/src/*\` (compiled output). To be regenerated when this lands and the package version is bumped.
- \`src/utils/clientRegistry.ts\`. The new fallback host there is part of the larger \`tf-dev\` refactor and will be migrated alongside that work.

### Companion changes already landed elsewhere

- \`dappros/ethora\` (main): canonical "Default backend" + new "Hosted services" tables in the monorepo README.
- \`dappros/ethora-chat-component\` (main): README updated to reference the new hosts and consolidate Swagger / playground / uptime links.
- \`dappros/ethora-chat-component-rn\` (main): same defaults migration + new README.
- \`dappros/ethora-app-reactjs\` (\`dev-tf\`): \`.env-example\`, \`index.html\`, \`Chat.tsx\` + improved README.
- \`dappros/ethora-bots\` (main), \`ethora-sdk-backend-integration\` (main), \`ethora-sdk-web-snippet\` (main), \`ethora-mcp-cli\` (main), \`ethora-setup\` (main): same migration applied.
- \`dappros/ethora-sdk-playground\`: PR [#1](https://github.com/dappros/ethora-sdk-playground/pull/1).

## Test plan

- [ ] CI passes (build / lint / typecheck)
- [ ] Manual: run the demo app from \`src/App.tsx\` and confirm the XMPP connection now goes to \`xmpp.chat.ethora.com:5443\`.
- [ ] Confirm \`src/assets/test.xml\` no longer contains \`atomwcapps.com\`.