### PR TITLE
Fix MUC join detection — accept presence with MUC xmlns when server skips id-echo

### DIFF
--- a/lib/src/networking/xmpp/presenceInRoom.xmpp.ts
+++ b/lib/src/networking/xmpp/presenceInRoom.xmpp.ts
@@ -43,12 +43,38 @@ export const presenceInRoom = async (
       }, delay);
     };
 
+    // Two ways a join can be confirmed:
+    //
+    // 1. The server echoes our presence stanza with the same `id` we
+    //    sent. Ejabberd does this; it's the strongest correlation.
+    // 2. A presence stanza arrives `from = roomJID/<resource>` and
+    //    carries a MUC namespace `<x xmlns=".../muc..."/>` child. This
+    //    is the standard XEP-0045 confirmation shape — every spec-
+    //    compliant MUC server emits it on successful join, even if it
+    //    doesn't echo our `id` back. Some non-Ejabberd deployments
+    //    (and older Ejabberd configs) skip the id-echo, which used to
+    //    cause the join to wait until timeout → reject → caller
+    //    treats it as failure → message resend loops → bubbles stuck
+    //    as "pending". The second match path closes that gap.
+    const isMucXmlnsChild = (child: Element): boolean =>
+      child?.name === 'x' &&
+      typeof child.attrs?.xmlns === 'string' &&
+      child.attrs.xmlns.startsWith('http://jabber.org/protocol/muc');
+
+    const matchesJoinConfirmation = (stanza: Element): boolean => {
+      if (!stanza.is('presence')) return false;
+      const from = stanza.attrs.from;
+      if (!from?.startsWith(roomJID)) return false;
+      // Fast path: id echo matches.
+      if (stanza.attrs.id === stanzaId) return true;
+      // Fallback path: must come from a /resource (i.e. an occupant
+      // self-presence, not the bare room jid) and carry a MUC <x>.
+      if (!from.includes('/')) return false;
+      return stanza.getChildren('x').some(isMucXmlnsChild);
+    };
+
     stanzaHandler = (stanza) => {
-      if (
-        stanza.is('presence') &&
-        stanza.attrs.id === stanzaId &&
-        stanza.attrs.from?.startsWith(roomJID)
-      ) {
+      if (matchesJoinConfirmation(stanza)) {
         if (stanza.attrs.type === 'error') {
           const errEl = stanza.getChild('error');
           const code =

--- a/src/networking/xmpp/presenceInRoom.xmpp.ts
+++ b/src/networking/xmpp/presenceInRoom.xmpp.ts
@@ -43,12 +43,38 @@ export const presenceInRoom = async (
       }, delay);
     };
 
+    // Two ways a join can be confirmed:
+    //
+    // 1. The server echoes our presence stanza with the same `id` we
+    //    sent. Ejabberd does this; it's the strongest correlation.
+    // 2. A presence stanza arrives `from = roomJID/<resource>` and
+    //    carries a MUC namespace `<x xmlns=".../muc..."/>` child. This
+    //    is the standard XEP-0045 confirmation shape — every spec-
+    //    compliant MUC server emits it on successful join, even if it
+    //    doesn't echo our `id` back. Some non-Ejabberd deployments
+    //    (and older Ejabberd configs) skip the id-echo, which used to
+    //    cause the join to wait until timeout → reject → caller
+    //    treats it as failure → message resend loops → bubbles stuck
+    //    as "pending". The second match path closes that gap.
+    const isMucXmlnsChild = (child: Element): boolean =>
+      child?.name === 'x' &&
+      typeof child.attrs?.xmlns === 'string' &&
+      child.attrs.xmlns.startsWith('http://jabber.org/protocol/muc');
+
+    const matchesJoinConfirmation = (stanza: Element): boolean => {
+      if (!stanza.is('presence')) return false;
+      const from = stanza.attrs.from;
+      if (!from?.startsWith(roomJID)) return false;
+      // Fast path: id echo matches.
+      if (stanza.attrs.id === stanzaId) return true;
+      // Fallback path: must come from a /resource (i.e. an occupant
+      // self-presence, not the bare room jid) and carry a MUC <x>.
+      if (!from.includes('/')) return false;
+      return stanza.getChildren('x').some(isMucXmlnsChild);
+    };
+
     stanzaHandler = (stanza) => {
-      if (
-        stanza.is('presence') &&
-        stanza.attrs.id === stanzaId &&
-        stanza.attrs.from?.startsWith(roomJID)
-      ) {
+      if (matchesJoinConfirmation(stanza)) {
         if (stanza.attrs.type === 'error') {
           const errEl = stanza.getChild('error');
           const code =


### PR DESCRIPTION
## Summary

Reimplements the fix from the original [#63](https://github.com/dappros/ethora-chat-component/pull/63) on top of current main. The original PR's head is on a fork I can't push to, so this is a fresh PR from a dappros-owned branch carrying the same intent.

\`presenceInRoom\` used to confirm a MUC join only when a presence stanza arrived with \`stanza.attrs.id === stanzaId\` (our generated \`presenceInRoom-<ts>-<n>\` id). Ejabberd echoes the id, so the deployments we test on work fine — but some non-Ejabberd MUC servers (and a few older Ejabberd configs) drop the id from their self-presence response. On those servers the handler never fires → caller hits \`presence_timeout\` → treats it as join failure → messages get stuck in \`pending\` and the auto-resend loop keeps re-emitting them.

## What changes

\`matchesJoinConfirmation\` now accepts either:

1. **Id-echo fast path** (existing behavior, unchanged): \`stanza.attrs.id === stanzaId\` AND \`from.startsWith(roomJID)\`.
2. **MUC-xmlns fallback** (new): \`from = roomJID/<resource>\` AND a child \`<x xmlns="http://jabber.org/protocol/muc...">\`.

Path 2 is the standard XEP-0045 join-confirmation shape — every spec-compliant MUC server emits it on a successful join, even if it doesn't echo our \`id\`. The \`from.includes('/')\` check prevents accidental matches against bare-jid room broadcasts (only occupant self-presence has a resource).

## What stays the same

All of main's accumulated improvements are preserved:

- Unique-id generation (\`presenceInRoom-<ts36>-<counter36>\`)
- \`isValidMucJid\` upfront guard
- Detailed error-code mapping (forbidden / not-allowed / remote-server-not-found / item-not-found)
- \`createTimeoutPromise\`-driven timeout-reject — **caller-visible behavior preserved**, no silent best-effort downgrade

Error stanzas still gate-keep on \`matchesJoinConfirmation\` and reject via the existing mapping, so the error UX is unchanged.

## lib/ stays in sync

Ran \`npm run sync:lib\` so the published artifact mirrors \`src/\`.

## Why not silent best-effort

The original PR proposed returning \`null\` on timeout (best-effort join). That's a behavior change for every caller — it would silently downgrade "server didn't respond at all" from "throw" to "soft-fail with empty presence", masking real connectivity bugs. Keeping the timeout-reject preserves that signal; the new fallback path means it only fires on genuine failures, not on spec-compliant servers that don't id-echo.

## Test plan

- [x] \`npx vitest run\` — existing 4 tests still pass (presenceInRoom has no direct unit tests yet; the test infrastructure work for that is on the qa-coverage track — PR #72).
- [ ] Manual: deploy against an Ejabberd instance — id-echo path still works.
- [ ] Manual: deploy against a server known to skip id-echo (or simulate via stripping the id from one outgoing presence response) — MUC-xmlns fallback should kick in.

## Test plan against an actual deployment

Roman / Dmytro to confirm whether the "messages stuck as pending after a server change" symptom is still observed in production. If yes → this PR addresses it. If no (i.e. the unique-id strategy already sufficient on all observed servers) → can close in favor of leaving \`#63\` as historical context.

## Supersedes

- [#63](https://github.com/dappros/ethora-chat-component/pull/63) — same intent, fresh rebase, dappros-side branch.