### PR TITLE
Fix package.json metadata (description, license, repo links)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,21 +81,33 @@
   "overrides": {
     "csstype": "3.1.3"
   },
-  "description": "1. npm create vite@latest 2. select name of project, select type (react/js) 3. cd project-name 4. npm i 5. npm i @ethora/chat-component 6. go to file src/App.tsx and replace it with this code",
+  "description": "Embeddable React chat UI for the open-source Ethora messaging platform — drop-in chat as a popup widget, an embedded panel, or a standalone app.",
+  "homepage": "https://playground.chat.ethora.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dappros/ethora-chat-component.git"
+  },
+  "bugs": {
+    "url": "https://github.com/dappros/ethora-chat-component/issues"
+  },
   "directories": {
     "lib": "lib"
   },
   "author": "Ethora",
-  "license": "AGPL",
+  "license": "MIT",
   "keywords": [
     "chat",
+    "chat-widget",
+    "embeddable-chat",
     "messaging",
+    "messaging-sdk",
     "react",
     "react-component",
-    "messenger",
     "reactjs",
-    "web3",
+    "typescript",
+    "tailwindcss",
     "xmpp",
+    "website-chatbot",
     "ethora"
   ]
 }


### PR DESCRIPTION
Cleanup of `package.json` fields that were either wrong or missing — these surface on the npm package page and are read by directory/listing crawlers.

## Changes

| Field | Before | After |
|---|---|---|
| `description` | a garbled `npm create vite...` install snippet | a proper one-line summary |
| `license` | `"AGPL"` | `"MIT"` |
| `homepage` | *(missing)* | `https://playground.chat.ethora.com` |
| `repository` | *(missing)* | the GitHub repo |
| `bugs` | *(missing)* | the issues URL |
| `keywords` | 9 keys incl. `messenger`, `web3` | aligned with the GitHub repo topics |

## Note on the license change

This is a **metadata correction, not a relicensing**. The repo's `LICENSE` file is the standard MIT License (`Copyright (c) 2025 Dappros Ltd`), and the GitHub repo is detected as MIT. `package.json` said `"AGPL"`, which both contradicts that file and isn't a valid SPDX identifier. This change makes `package.json` agree with the existing `LICENSE` file.

## Why now

The npm page currently shows no repository link and a nonsense description, which weakens the package on npm and blocks clean submission to component directories. No code changes — metadata only.